### PR TITLE
Add settings to __init__.py

### DIFF
--- a/molecule/__init__.py
+++ b/molecule/__init__.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+
+###############################################################################
+#                                                                             #
+# RMG - Reaction Mechanism Generator                                          #
+#                                                                             #
+# Copyright (c) 2002-2021 Prof. William H. Green (whgreen@mit.edu),           #
+# Prof. Richard H. West (r.west@neu.edu) and the RMG Team (rmg_dev@mit.edu)   #
+#                                                                             #
+# Permission is hereby granted, free of charge, to any person obtaining a     #
+# copy of this software and associated documentation files (the 'Software'),  #
+# to deal in the Software without restriction, including without limitation   #
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
+# and/or sell copies of the Software, and to permit persons to whom the       #
+# Software is furnished to do so, subject to the following conditions:        #
+#                                                                             #
+# The above copyright notice and this permission notice shall be included in  #
+# all copies or substantial portions of the Software.                         #
+#                                                                             #
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,    #
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE #
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER      #
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING     #
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         #
+# DEALINGS IN THE SOFTWARE.                                                   #
+#                                                                             #
+###############################################################################
+
+"""
+This is the rmg module.
+"""
+
+import os
+import os.path
+
+from rmgpy.version import __version__
+from rmgpy.exceptions import SettingsError
+
+
+################################################################################
+
+class Settings(dict):
+    """
+    A dictionary-like object containing global settings for RMG jobs. These
+    settings are generally loaded from a file named ``rmgrc`` located at one
+    of several possible places on disk. The ``rmgrc`` file used is stored in
+    the `filename` attribute. This class inherits from the built-in dict class
+    and adds methods for loading and resetting the settings, as well as a
+    custom :meth:`__setitem__` method for processing the setting values before
+    adding them to the dictionary.
+    
+    In general you should be working with the module-level variable
+    ``settings`` in this module, which is an instance of this class.
+    """
+
+    def __init__(self, path=None):
+        super(Settings, self).__init__()
+        self.filename = None
+        self.sources = dict()
+        self.load(path)
+
+    def __setitem__(self, key, value):
+        if key == 'database.directory':
+            value = os.path.abspath(os.path.expandvars(value))
+        elif key == 'test_data.directory':
+            value = os.path.abspath(os.path.expandvars(value))
+        else:
+            raise SettingsError('Unexpecting setting "{0}" encountered.'.format(key))
+        self.sources[key] = '-'
+        super(Settings, self).__setitem__(key, value)
+
+    def report(self):
+        """
+        Returns a string saying what is set and where things came from, suitable for logging
+        """
+        lines = ['Global RMG Settings:']
+        for key in self.keys():
+            lines.append("   {0:20s} = {1:20s} ({2})".format(key, self[key], self.sources[key]))
+        return '\n'.join(lines)
+
+    def load(self, path=None):
+        """
+        Load settings from a file on disk. If an explicit file is not specified,
+        the following locations will be searched for a settings file, and the
+        first one found will be loaded:
+        
+        * An rmgrc file in the current working directory
+        
+        * An rmgrc file in the user's $HOME/.rmg directory
+        
+        * An rmgrc file in the same directory as this package
+        
+        If none of these can be found, a SettingsError is raised.
+        """
+        # First set all settings to their default values
+        self.reset()
+
+        if path:
+            # The user specified an explicit file to use for the settings
+            # Make sure that it exists, fail if it does not
+            if not os.path.exists(path):
+                raise SettingsError('Specified RMG settings file "{0}" does not exist.'.format(path))
+            else:
+                self.filename = path
+        else:
+            # The user did not specify an explicit file to use for the settings
+            # Load one of the default settings files instead
+            working_dir = os.path.abspath(os.path.dirname(__file__))
+            if os.path.exists('rmgrc'):
+                self.filename = 'rmgrc'
+            elif os.path.exists(os.path.expanduser('~/.rmg/rmgrc')):
+                self.filename = os.path.expanduser('~/.rmg/rmgrc')
+            elif os.path.exists(os.path.join(working_dir, 'rmgrc')):
+                self.filename = os.path.join(working_dir, 'rmgrc')
+            else:
+                return  # fail silently, instead of raising an error
+
+        # From here on we assume that we have identified the appropriate
+        # settings file to load
+
+        with open(self.filename, 'r') as f:
+            for line in f:
+                # Remove any comments from the line
+                index = line.find('#')
+                if index != -1:
+                    line = line[:index]
+                # Is there a key-value pair remaining?
+                if line.find('database.directory') != -1:
+                    value = line.split()[-1]  # Get the last token from this line
+                    value = value.strip()
+                    self['database.directory'] = value
+                    self.sources['database.directory'] = "from {0}".format(self.filename)
+
+                elif line.find('test_data.directory') != -1:
+                    value = line.split()[-1]  # Get the last token from this line
+                    value = value.strip()
+                    self['test_data.directory'] = value
+                    self.sources['test_data.directory'] = "from {0}".format(self.filename)
+
+    def reset(self):
+        """
+        Reset all settings to their default values.
+        """
+        self.filename = None
+        rmgpy_module_dir = os.path.abspath(os.path.dirname(__file__))
+        self['database.directory'] = os.path.realpath(
+            os.path.join(rmgpy_module_dir, '..', '..', 'RMG-database', 'input'))
+        self.sources['database.directory'] = 'Default, relative to RMG-Py source code'
+        self['test_data.directory'] = os.path.realpath(os.path.join(rmgpy_module_dir, 'test_data'))
+        self.sources['test_data.directory'] = 'Default, relative to RMG-Py source code'
+
+
+# The global settings object
+settings = Settings(path=None)
+
+
+################################################################################
+
+def get_path():
+    """
+    Return the directory that this file is found in on disk.
+    """
+    return os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
`settings` is imported [here](https://github.com/ReactionMechanismGenerator/molecule/blob/main/molecule/data/kinetics/family.py#L47) and many other places in this repo, but it's never defined. 

It causes the following [error](https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl/actions/runs/5226942087/jobs/9438071481?pr=218#step:6:37) when I try to switch RMS's dependency from RMG to Molecule.

```
ImportError("cannot import name 'settings' from 'molecule' (/usr/share/miniconda/envs/rms_env/lib/python3.7/site-packages/molecule/__init__.py)")
  File "molecule/chemkin.pyx", line 45, in init molecule.chemkin
  File "/usr/share/miniconda/envs/rms_env/lib/python3.7/site-packages/molecule/data/kinetics/__init__.py", line 30, in <module>
    from molecule.data.kinetics.database import KineticsDatabase
  File "/usr/share/miniconda/envs/rms_env/lib/python3.7/site-packages/molecule/data/kinetics/database.py", line 41, in <module>
    from molecule.data.kinetics.family import KineticsFamily
  File "/usr/share/miniconda/envs/rms_env/lib/python3.7/site-packages/molecule/data/kinetics/family.py", line 47, in <module>
    from molecule import settings
```

I copied the settings code from RMG.